### PR TITLE
add link to the page source to the footer

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -201,6 +201,10 @@ link = "https://sg1.run/ccoss-slack"
 name = "?Quién organiza¿"
 link = "/team/"
 
+[[params.footer_source]]
+name = "Código fuente del sitio"
+link = "https://github.com/softwareguru/ccoss-website"
+
 [[params.footer_previous]]
 name = "Prospectus"
 link = "/files/CCOSS2022 Hybrid - Prospectus.pdf"

--- a/themes/ccoss/layouts/partials/footer.html
+++ b/themes/ccoss/layouts/partials/footer.html
@@ -9,12 +9,15 @@
 					<li class="list-inline-item"><a href="{{ .link | safeURL }}" target="_blank"><i class="{{ .icon }}"></i></a></li>
 					{{ end }}
 				</ul>
-			</div>			
+			</div>
 			<div>
 				<h5>Acerca de</h5>
 				<ul class="footer_links">
 					{{ range .Site.Params.footer_about }}
 					<li><a href="{{ .link | safeURL }}">{{ .name }}</a></li>
+					{{ end }}
+					{{ range .Site.Params.footer_source }}
+					<li><a href="{{ .link | safeURL }}" target="_blank" rel="noopener">{{ .name }}</a></li>
 					{{ end }}
 				</ul>
 			</div>
@@ -37,8 +40,8 @@
 		</div>
 		{{ with .Site.Params.disclaimer }}
 		<div class="disclaimer">
-			{{ . }}  
-		</div>			
+			{{ . }}
+		</div>
         {{ end }}
 	</div>
 </footer>
@@ -52,4 +55,3 @@
 {{ "<!-- Main Script -->" | safeHTML }}
 {{ $script := resources.Get "js/script.js" | minify}}
 <script src="{{ $script.Permalink }}"></script>
-


### PR DESCRIPTION
This will make it easier to contribute. I was trying to find the source and it wasn't obvious that it was under the softwareguru organization.

Thanks for organizing this event!

It's worth noticing that this file has mixed indent (both tabs AND spaces in use). Some others just have unaligned tags, but that's a matter for another PR I guess.

This is what the change looks like:

![Captura desde 2022-09-26 20-38-32](https://user-images.githubusercontent.com/790756/192405151-c8187b58-a9a1-48e8-9b9e-082a4987e800.png)