### PR TITLE
use minmax trick to have allways-responsive grid columns

### DIFF
--- a/themes/ccoss/assets/scss/_custom.scss
+++ b/themes/ccoss/assets/scss/_custom.scss
@@ -81,13 +81,8 @@ section.register p, section.swag p {
 
 .team-strip {
 	display: grid;
-	grid-template-columns: repeat(3, 1fr);
+	grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
 	grid-gap: 20px;
-
-	@include mobile {
-		grid-template-columns: repeat(2, 1fr);
-	}
-
 }
 
 .profile-item .headshot {
@@ -232,19 +227,19 @@ section.sponsors {
 		font-size: 40px;
 	}
 }
-  
+
   .event-info .content {
 	display: grid;
 	grid-gap: 32px;
 	grid-template-columns: 1fr;
-  
+
 	@media (min-width:640px) {
 	  grid-gap: 64px;
-	  grid-template-columns: repeat(auto-fit, minmax(450px, 1fr));    
+	  grid-template-columns: repeat(auto-fit, minmax(450px, 1fr));
 	}
-  
+
   }
-  
+
   .statistics-block {
 	display: grid;
 	width:100%;
@@ -254,16 +249,16 @@ section.sponsors {
 	  grid-gap: 32px;
 	}
   }
-  
+
   .statistics-block .numbers {
 	font-size: 40px;
 	word-spacing: 0.0em;
-	line-height: 27pt;     
+	line-height: 27pt;
 	@media (min-width:640px) {
 	  grid-gap: 56px;
 	}
   }
-  
+
   .statistics-block .numbers:after {
 	content: "";
 	display: block;
@@ -272,7 +267,7 @@ section.sponsors {
 	background-color: $yellow;
 	margin-top:10px;
   }
-  
+
   .statistics-block .label {
 	margin-top: 4px;
   }
@@ -287,7 +282,7 @@ section.sponsors {
 
 .list-content {
 	margin-bottom: 1.6em;
-}	
+}
 
 #event-info {
 	display: block;


### PR DESCRIPTION
If you check https://ccoss.org/team/ right now it doesn't work on mobile. Some organizers are lost outside of the view and a `overflow: hidden` rule prevents horizontal scrolling.

This PR changes the grid columns from a fixed layout ot 3 columns to a minmax that changes the number of columns  if necessary.

## Before

[Grabación de pantalla desde 26-09-22 20:49:41.webm](https://user-images.githubusercontent.com/790756/192406613-8248e8ff-40e9-4dd2-90e7-2b483a92fc9e.webm)

## After

[Grabación de pantalla desde 26-09-22 20:50:10.webm](https://user-images.githubusercontent.com/790756/192406631-6d0a7499-90a3-4041-a7a3-07bb682dfd55.webm)